### PR TITLE
Cache installation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,6 @@ heroku-buildpack-imagemagick
 
 This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) for vendoring the ImageMagick binaries into your project.
 
-Set the version using the IMAGE_MAGICK_VERSION env var in your environment.
+Caches the installation  between builds.
+
+Tested and working as of 2020-09-27

--- a/bin/compile
+++ b/bin/compile
@@ -51,7 +51,7 @@ if [ ! -f $CACHE_FILE ]; then
 else
   # cache exists, extract it
   echo "-----> Extracting ImageMagick $CACHE_FILE => $VENDOR_DIR"
-  mkdir ${BUILD_PATH}
+  mkdir "$BUILD_PATH"
   tar xzf $CACHE_FILE -C $VENDOR_DIR
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -51,6 +51,7 @@ if [ ! -f $CACHE_FILE ]; then
 else
   # cache exists, extract it
   echo "-----> Extracting ImageMagick $CACHE_FILE => $VENDOR_DIR"
+  mkdir -p $(dirname $BUILD_PATH)
   tar xzf $CACHE_FILE -C $VENDOR_DIR
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -15,7 +15,7 @@ CACHE_FILE="$CACHE_DIR/imagemagick.tar.gz"
 
 if [ ! -f $CACHE_FILE ]; then
   # install imagemagick
-  IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-6.9.3-10}"
+  IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-7.0.10-29}"
   IMAGE_MAGICK_FILE="ImageMagick-$IMAGE_MAGICK_VERSION.tar.xz"
   IMAGE_MAGICK_DIR="ImageMagick-$IMAGE_MAGICK_VERSION"
   # SSL cert used on imagemagick not recognized by heroku.

--- a/bin/compile
+++ b/bin/compile
@@ -51,7 +51,7 @@ if [ ! -f $CACHE_FILE ]; then
 else
   # cache exists, extract it
   echo "-----> Extracting ImageMagick $CACHE_FILE => $VENDOR_DIR"
-  mkdir -p ($BUILD_PATH)
+  mkdir -p $($BUILD_PATH)
   tar xzf $CACHE_FILE -C $VENDOR_DIR
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -51,7 +51,7 @@ if [ ! -f $CACHE_FILE ]; then
 else
   # cache exists, extract it
   echo "-----> Extracting ImageMagick $CACHE_FILE => $VENDOR_DIR"
-  mkdir -p $(dirname $BUILD_PATH)
+  mkdir -p $BUILD_PATH
   tar xzf $CACHE_FILE -C $VENDOR_DIR
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -51,7 +51,7 @@ if [ ! -f $CACHE_FILE ]; then
 else
   # cache exists, extract it
   echo "-----> Extracting ImageMagick $CACHE_FILE => $VENDOR_DIR"
-  mkdir -p "$BUILD_DIR"
+  mkdir -p "$VENDOR_DIR"
   tar xzf $CACHE_FILE -C $VENDOR_DIR
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -51,7 +51,7 @@ if [ ! -f $CACHE_FILE ]; then
 else
   # cache exists, extract it
   echo "-----> Extracting ImageMagick $CACHE_FILE => $VENDOR_DIR"
-  mkdir -p $BUILD_PATH
+  mkdir ${BUILD_PATH}
   tar xzf $CACHE_FILE -C $VENDOR_DIR
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -51,7 +51,7 @@ if [ ! -f $CACHE_FILE ]; then
 else
   # cache exists, extract it
   echo "-----> Extracting ImageMagick $CACHE_FILE => $VENDOR_DIR"
-  mkdir -p "$BUILD_PATH"
+  mkdir -p "$BUILD_DIR"
   tar xzf $CACHE_FILE -C $VENDOR_DIR
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -51,7 +51,7 @@ if [ ! -f $CACHE_FILE ]; then
 else
   # cache exists, extract it
   echo "-----> Extracting ImageMagick $CACHE_FILE => $VENDOR_DIR"
-  mkdir -p $($BUILD_PATH)
+  mkdir -p "$BUILD_PATH"
   tar xzf $CACHE_FILE -C $VENDOR_DIR
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -51,7 +51,7 @@ if [ ! -f $CACHE_FILE ]; then
 else
   # cache exists, extract it
   echo "-----> Extracting ImageMagick $CACHE_FILE => $VENDOR_DIR"
-  mkdir "$BUILD_PATH"
+  mkdir ($BUILD_PATH)
   tar xzf $CACHE_FILE -C $VENDOR_DIR
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -51,7 +51,7 @@ if [ ! -f $CACHE_FILE ]; then
 else
   # cache exists, extract it
   echo "-----> Extracting ImageMagick $CACHE_FILE => $VENDOR_DIR"
-  mkdir ($BUILD_PATH)
+  mkdir -p ($BUILD_PATH)
   tar xzf $CACHE_FILE -C $VENDOR_DIR
 fi
 


### PR DESCRIPTION
Fixed the cache installation error caused by a missing $VENDOR_DIR when re-building between deploys.